### PR TITLE
Minor fixes for libvirt-guests service

### DIFF
--- a/app-emulation/libvirt/files/libvirt-guests.confd
+++ b/app-emulation/libvirt/files/libvirt-guests.confd
@@ -9,16 +9,16 @@
 
 # LIBVIRT_SHUTDOWN
 # Valid options:
-# * shutdown - Sends an ACPI shutdown (think of this as a request to your guest
-#              to shutdown). There is no way to distinguish between guests that
-#              are ignoring the shutdown request or are stuck or are taking
-#              a long time to shutdown. We will wait LIBVIRT_MAXWAIT seconds
-#              before yanking the power out.
-# * suspend  - Performs a state save external to the VM. qemu-kvm will stop
-#              stop the CPU and save off all state to a separate file. When
-#              the machine is started again, it will resume like nothing ever
-#              happened. This is guarenteed to always successfully stop your
-#              machine and restart it.
+# * shutdown -    Sends an ACPI shutdown (think of this as a request to your guest
+#                 to shutdown). There is no way to distinguish between guests that
+#                 are ignoring the shutdown request or are stuck or are taking
+#                 a long time to shutdown. We will wait LIBVIRT_MAXWAIT seconds
+#                 before yanking the power out.
+# * managedsave - Performs a state save external to the VM. qemu-kvm will stop
+#                 stop the CPU and save off all state to a separate file. When
+#                 the machine is started again, it will resume like nothing ever
+#                 happened. This is guarenteed to always successfully stop your
+#                 machine and restart it.
 
 #LIBVIRT_SHUTDOWN="suspend"
 

--- a/app-emulation/libvirt/files/libvirt-guests.confd
+++ b/app-emulation/libvirt/files/libvirt-guests.confd
@@ -1,7 +1,7 @@
 # /etc/conf.d/libvirtd
 
 # LIBVIRT_URIS
-# libvirt URIs to communicate with to start/stop guests
+# space separated list of libvirt URIs to communicate with to start/stop guests
 # Valid values are anything that can be passed to 'virsh connect'
 
 #LIBVIRT_URIS="qemu:///system"

--- a/app-emulation/libvirt/files/libvirt-guests.confd
+++ b/app-emulation/libvirt/files/libvirt-guests.confd
@@ -3,8 +3,9 @@
 # LIBVIRT_URIS
 # libvirt URIs to communicate with to start/stop guests
 # Valid values are anything that can be passed to 'virsh connect'
-#
+
 #LIBVIRT_URIS="qemu:///system"
+
 
 # LIBVIRT_SHUTDOWN
 # Valid options:
@@ -18,19 +19,23 @@
 #              the machine is started again, it will resume like nothing ever
 #              happened. This is guarenteed to always successfully stop your
 #              machine and restart it.
+
 #LIBVIRT_SHUTDOWN="suspend"
+
 
 # LIBVIRT_MAXWAIT
 # Timeout in seconds until stopping a guest and "pulling the plug" on the
 # guest
 # Valid values are any integer over 0
+
 #LIBVIRT_MAXWAIT="500"
+
 
 # LIBVIRT_NET_SHUTDOWN
 # If libvirtd created networks for you (e.g. NATed networks) then this init
 # script will shut them down for you if this is set to 'yes'. Otherwise,
-# the networks will be left running once libvirt is shutdown. For this
-# option to be useful you must have enabled the 'virt-network' USE flag and
-# have had libvirt create a NATed network for you.
-# Valid values: 'yes' or 'no'
+# the networks will be left running. For this option to be useful you must
+# have enabled the 'virt-network' USE flag and have had libvirt create a
+# NATed network for you. Valid values: 'yes' or 'no'
+
 #LIBVIRT_NET_SHUTDOWN="yes"

--- a/app-emulation/libvirt/files/libvirt-guests.confd
+++ b/app-emulation/libvirt/files/libvirt-guests.confd
@@ -9,16 +9,24 @@
 
 # LIBVIRT_SHUTDOWN
 # Valid options:
-# * shutdown -    Sends an ACPI shutdown (think of this as a request to your guest
-#                 to shutdown). There is no way to distinguish between guests that
-#                 are ignoring the shutdown request or are stuck or are taking
-#                 a long time to shutdown. We will wait LIBVIRT_MAXWAIT seconds
-#                 before yanking the power out.
-# * managedsave - Performs a state save external to the VM. qemu-kvm will stop
-#                 stop the CPU and save off all state to a separate file. When
-#                 the machine is started again, it will resume like nothing ever
-#                 happened. This is guarenteed to always successfully stop your
-#                 machine and restart it.
+# * managedsave - Performs a state save external to the VM (for hypervisors
+#                 supporting this operation). qemu-kvm will stop stop the
+#                 CPU and save off all state to a separate file. When the
+#                 machine is started again, it will resume like nothing
+#                 ever happened. This is guarenteed to always successfully
+#                 stop your machine and restart it.
+#
+# * shutdown -    Sends an ACPI shutdown (think of this as a request to
+#                 your guest to shutdown). There is no way to distinguish
+#                 between guests that are ignoring the shutdown request or
+#                 are stuck or are taking a long time to shutdown. We will
+#                 wait LIBVIRT_MAXWAIT seconds before yanking the power
+#                 out.
+#
+# * destroy  -    Immediately stop all running guests. Use with caution as
+#                 this can leave the guest in a corrupted state and might
+#                 lead to data loss.
+#
 
 #LIBVIRT_SHUTDOWN="suspend"
 

--- a/app-emulation/libvirt/files/libvirt-guests.init
+++ b/app-emulation/libvirt/files/libvirt-guests.init
@@ -11,7 +11,7 @@ depend() {
 
 # default to suspending the VM via managedsave
 case "${LIBVIRT_SHUTDOWN}" in
-	managedsave|shutdown) ;;
+	managedsave|shutdown|destroy) ;;
 	*) LIBVIRT_SHUTDOWN="managedsave" ;;
 esac
 

--- a/app-emulation/libvirt/files/libvirt-guests.init
+++ b/app-emulation/libvirt/files/libvirt-guests.init
@@ -8,11 +8,13 @@ depend() {
 
 # set the default to QEMU
 [ -z ${LIBVIRT_URIS} ] && LIBVIRT_URIS="qemu:///system"
+
 # default to suspending the VM via managedsave
 case "${LIBVIRT_SHUTDOWN}" in
 	managedsave|shutdown) ;;
 	*) LIBVIRT_SHUTDOWN="managedsave" ;;
 esac
+
 # default to 500 seconds
 [ -z ${LIBVIRT_MAXWAIT} ] && LIBVIRT_MAXWAIT=500
 
@@ -20,23 +22,23 @@ gueststatefile="/var/lib/libvirt/libvirt-guests.state"
 netstatefile="/var/lib/libvirt/libvirt-net.state"
 
 do_virsh() {
-    local hvuri=$1
-    shift
+	local hvuri=$1
+	shift
 
 	# if unset, default to qemu
 	[ -z ${hvuri} ] && hvuri="qemu:///system"
 	# if only qemu was supplied then correct the value
 	[ "xqemu" = x${hvuri} ] && hvuri="qemu:///system"
 
-    # Silence errors because virsh always throws an error about
-    # not finding the hypervisor version when connecting to libvirtd
+	# Silence errors because virsh always throws an error about
+	# not finding the hypervisor version when connecting to libvirtd
 	# lastly strip the blank line at the end
-    LC_ALL=C virsh -c ${hvuri} "$@" 2>/dev/null | head -n -1
+	LC_ALL=C virsh -c ${hvuri} "$@" 2>/dev/null | head -n -1
 }
 
 libvirtd_dom_list() {
-    # Only work with domains by their UUIDs
-    do_virsh "$1" list --uuid $2
+	# Only work with domains by their UUIDs
+	do_virsh "$1" list --uuid $2
 }
 
 libvirtd_dom_count() {
@@ -44,8 +46,8 @@ libvirtd_dom_count() {
 }
 
 libvirtd_net_list() {
-    # Only work with networks by their UUIDs
-    do_virsh "$1" net-list --uuid $2
+	# Only work with networks by their UUIDs
+	do_virsh "$1" net-list --uuid $2
 }
 
 libvirtd_net_count() {
@@ -60,9 +62,9 @@ libvirtd_dom_stop() {
 	local uri=$1
 	local persist=$2
 	local shutdown_type=${LIBVIRT_SHUTDOWN}
-    local counter=${LIBVIRT_MAXWAIT}
-    local dom_name=
-    local dom_ids=
+	local counter=${LIBVIRT_MAXWAIT}
+	local dom_name=
+	local dom_ids=
 	local uuid=
 	local dom_count=
 
@@ -188,10 +190,10 @@ start() {
 }
 
 stop() {
-    local counter=
-    local dom_name=
-    local net_name=
-    local dom_ids=
+	local counter=
+	local dom_name=
+	local net_name=
+	local dom_ids=
 	local uuid=
 	local dom_count=
 

--- a/app-emulation/libvirt/files/libvirtd.init-r15
+++ b/app-emulation/libvirt/files/libvirtd.init-r15
@@ -3,33 +3,33 @@
 description="Virtual Machine Management daemon (libvirt)"
 
 depend() {
-    USE_FLAG_FIREWALLD
-    use USE_FLAG_AVAHI USE_FLAG_ISCSI USE_FLAG_RBD dbus virtlockd
-    after ntp-client ntpd nfs nfsmount portmap rpc.statd iptables ip6tables ebtables corosync sanlock cgconfig xenconsoled
+	USE_FLAG_FIREWALLD
+	use USE_FLAG_AVAHI USE_FLAG_ISCSI USE_FLAG_RBD dbus virtlockd
+	after ntp-client ntpd nfs nfsmount portmap rpc.statd iptables ip6tables ebtables corosync sanlock cgconfig xenconsoled
 }
 
 start() {
-    # Test configuration directories in /etc/libvirt/ to be either not
-    # present or a directory, i.e. not a regular file, bug #532892
-    for dir in lxc nwfilter qemu storage; do
-      if [ -f /etc/libvirt/$dir ]; then
-        eerror "/etc/libvirt/$dir was created as a regular file. It must be either"
-        eerror "a directory or not present for libvirtd to start up successfully."
-        return 1
-      fi
-    done
+	# Test configuration directories in /etc/libvirt/ to be either not
+	# present or a directory, i.e. not a regular file, bug #532892
+	for dir in lxc nwfilter qemu storage; do
+		if [ -f /etc/libvirt/$dir ]; then
+			eerror "/etc/libvirt/$dir was created as a regular file. It must be either"
+			eerror "a directory or not present for libvirtd to start up successfully."
+			return 1
+		fi
+	done
 
-    ebegin "Starting libvirtd"
-    start-stop-daemon --start \
-        --env KRB5_KTNAME=/etc/libvirt/krb5.tab \
-        --exec /usr/sbin/libvirtd --pidfile=/var/run/libvirtd.pid \
+	ebegin "Starting libvirtd"
+	start-stop-daemon --start \
+		--env KRB5_KTNAME=/etc/libvirt/krb5.tab \
+		--exec /usr/sbin/libvirtd --pidfile=/var/run/libvirtd.pid \
 		-- -d ${LIBVIRTD_OPTS}
-    eend $?
+	eend $?
 }
 
 stop() {
-    ebegin "Stopping libvirtd without shutting down your VMs"
-    start-stop-daemon --stop --quiet --exec \
-        /usr/sbin/libvirtd --pidfile=/var/run/libvirtd.pid
-    eend $?
+	ebegin "Stopping libvirtd without shutting down your VMs"
+	start-stop-daemon --stop --quiet --exec \
+		/usr/sbin/libvirtd --pidfile=/var/run/libvirtd.pid
+	eend $?
 }


### PR DESCRIPTION
Hi @cardoe,

after thinking about the current init script situation I came to the conclusion that converting `libvirt-guests.init` to a `libvirt-guests.sh` variant might not be too terribly beneficial at all. Especially because both variants lack proper full support for managing different hypervisors simultaneously, etc.

Therefore, I'd suggest we just go forward with this change and properly fix the whole business for openrc and systemd with a proper rewrite of upstream's `libvirt-guests.sh` script at some point. (I'm quite time constraint at the moment.)

I have looked through your `libvirt-guests.init` file and found one minor mistake: The `libvirt-guests.confd` talks about `suspend`, but `managedsave` is the correct configuration option.

What about the following, minor changes:
- Convert `LIBVIRT_URIS` into a space separated list of connections and loop over those in `start()` and `stop()`
- Also allow `destroy` as configuration option in `LIBVIRT_SHUTDOWN`?
